### PR TITLE
TOOLS-607 mountain-gorilla py file missing copyright.

### DIFF
--- a/tools/rm-old-builds.py
+++ b/tools/rm-old-builds.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python
 #
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright (c) 2014, Joyent, Inc.
+#
+
+#
 # Remove old builds under here. This presumes the MG-uploaded
 # structure (see:
 # <https://mo.joyent.com/mountain-gorilla/blob/master/tools/upload-bits>)


### PR DESCRIPTION
- license-file tool wasn't checking py files previously.
