### PR TITLE
TOOLS-1983 How to avoid hard failure of most builds on Feb 22 from GitHub weak crypto removal

### DIFF
--- a/targets.json.in
+++ b/targets.json.in
@@ -75,7 +75,7 @@ if [[ "${JOYENT_BUILD}" == "true" ]]; then
   FIRMWARE_TOOLS_DEP='"firmware-tools",'
   FIRMWARE_TOOLS_ENTRY='
   "firmware-tools": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/firmware-tools.git"}
     ],
@@ -93,7 +93,7 @@ fi
 cat <<EOF
 {
   "smartlogin": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-smart-login.git"}
     ],
@@ -102,7 +102,7 @@ cat <<EOF
   },
   "ca": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "ca",
     "image_description": "SDC Cloud Analytics",
     "image_version": "1.0.0",
@@ -132,7 +132,7 @@ cat <<EOF
   },
   "amon": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "amon",
     "image_description": "SDC AMON",
     "image_version": "1.0.0",
@@ -155,7 +155,7 @@ cat <<EOF
   },
   "assets": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "assets",
     "image_description": "SDC Assets",
     "image_version": "1.0.0",
@@ -176,7 +176,7 @@ cat <<EOF
   },
   "cns": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "cns",
     "image_description": "Triton Container Naming Service",
     "image_version": "1.0.0",
@@ -202,7 +202,7 @@ cat <<EOF
   },
   "adminui": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "adminui",
     "image_description": "SDC AdminUI",
     "image_version": "1.0.0",
@@ -229,7 +229,7 @@ cat <<EOF
   },
   "mockcloud": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "mockcloud",
     "image_description": "SDC MOCK CLOUD",
     "image_version": "1.0.0",
@@ -246,7 +246,7 @@ cat <<EOF
   },
   "nfsserver": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "nfsserver",
     "image_description": "SDC NFS Server",
     "image_version": "1.0.0",
@@ -265,7 +265,7 @@ cat <<EOF
   },
   "dhcpd": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "dhcpd",
     "image_description": "SDC DHCPD",
     "image_version": "1.0.0",
@@ -293,7 +293,7 @@ cat <<EOF
   },
   "amonredis": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "amonredis",
     "image_description": "SDC Amon Redis",
     "image_version": "1.0.0",
@@ -316,7 +316,7 @@ cat <<EOF
   },
   "rabbitmq": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "rabbitmq",
     "image_description": "SDC RabbitMQ",
     "image_version": "1.0.0",
@@ -348,7 +348,7 @@ cat <<EOF
   },
   "cloudapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "cloudapi",
     "image_description": "SDC CloudAPI",
     "image_version": "1.0.0",
@@ -383,7 +383,7 @@ cat <<EOF
   },
   "nat": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "nat",
     "image_description": "SmartDataCenter per-user NAT zone",
     "image_version": "1.0.0",
@@ -398,7 +398,7 @@ cat <<EOF
   },
   "docker": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "docker",
     "image_description": "SDC Docker Engine",
     "image_version": "1.0.0",
@@ -429,7 +429,7 @@ cat <<EOF
   },
   "volapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "volapi",
     "image_description": "SDC Volumes API",
     "image_version": "1.0.0",
@@ -460,7 +460,7 @@ cat <<EOF
   },
   "portolan": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "portolan",
     "image_description": "SDC Portolan Service",
     "image_version": "1.0.0",
@@ -485,7 +485,7 @@ cat <<EOF
 
   "ufds": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "ufds",
     "image_description": "SDC UFDS",
     "image_version": "1.0.0",
@@ -513,7 +513,7 @@ cat <<EOF
 
   "workflow": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "workflow",
     "image_description": "SDC Workflow",
     "image_version": "1.0.0",
@@ -577,7 +577,7 @@ cat <<EOF
 
   "vmapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "vmapi",
     "image_description": "SDC VMAPI",
     "image_version": "1.0.0",
@@ -609,7 +609,7 @@ cat <<EOF
 
   "papi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "papi",
     "image_description": "SDC PAPI",
     "image_version": "1.0.0",
@@ -641,7 +641,7 @@ cat <<EOF
 
   "imgapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "imgapi",
     "image_description": "SDC IMGAPI",
     "// image_uuid": "sdc-minimal-multiarch-lts@15.4.1",
@@ -680,7 +680,7 @@ cat <<EOF
 
   "sdc": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "sdc",
     "image_description": "SDC tools/ops zone",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -703,7 +703,7 @@ cat <<EOF
   },
 
   "agents_core": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-agents-core.git"}
     ],
@@ -714,7 +714,7 @@ cat <<EOF
   },
 
   "vm-agent": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-vm-agent.git"}
     ],
@@ -725,7 +725,7 @@ cat <<EOF
   },
 
   "net-agent": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-net-agent.git"}
     ],
@@ -736,7 +736,7 @@ cat <<EOF
   },
 
   "cn-agent": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-cn-agent.git"}
     ],
@@ -747,7 +747,7 @@ cat <<EOF
   },
 
   "config-agent": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-config-agent.git"}
     ],
@@ -758,7 +758,7 @@ cat <<EOF
   },
 
   "hagfish-watcher": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-hagfish-watcher.git"}
     ],
@@ -769,7 +769,7 @@ cat <<EOF
   },
 
   "firewaller": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-firewaller-agent.git"}
     ],
@@ -781,7 +781,7 @@ cat <<EOF
 
   "cnapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "cnapi",
     "image_description": "SDC CNAPI",
     "image_version": "1.0.0",
@@ -806,7 +806,7 @@ cat <<EOF
 
   "fwapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "fwapi",
     "image_description": "SDC FWAPI",
     "image_version": "1.0.0",
@@ -833,7 +833,7 @@ cat <<EOF
 
   "napi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "napi",
     "image_description": "SDC NAPI",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -859,7 +859,7 @@ cat <<EOF
 
   "sapi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "sapi",
     "image_description": "SDC SAPI",
     "image_version": "1.0.0",
@@ -883,7 +883,7 @@ cat <<EOF
   },
 
   "registrar": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/registrar.git"}
     ],
@@ -894,7 +894,7 @@ cat <<EOF
   },
 
   "minnow": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/manta-minnow.git"}
     ],
@@ -905,7 +905,7 @@ cat <<EOF
   },
 
   "mackerel": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/manta-mackerel.git"}
     ],
@@ -917,7 +917,7 @@ cat <<EOF
 
   "binder": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-nameservice",
     "image_description": "Manta nameservice",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -945,7 +945,7 @@ cat <<EOF
 
   "manta-manatee": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-postgres",
     "image_description": "Manta manatee",
     "// image_uuid": "triton-origin-multiarch-15.4.1@1.0.1",
@@ -972,7 +972,7 @@ cat <<EOF
 
   "sdc-manatee": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "sdc-postgres",
     "image_description": "SDC manatee",
     "image_uuid": "b4bdc598-8939-11e3-bea4-8341f6861379",
@@ -1004,7 +1004,7 @@ cat <<EOF
 
   "medusa": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-medusa",
     "image_description": "Manta medusa",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1030,7 +1030,7 @@ cat <<EOF
 
   "mahi": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-authcache",
     "image_description": "Manta authcache",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1057,7 +1057,7 @@ cat <<EOF
 
   "moray": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-moray",
     "image_description": "Manta moray",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1085,7 +1085,7 @@ cat <<EOF
 
   "electric-moray": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-electric-moray",
     "image_description": "Manta moray proxy",
     "image_uuid": "b4bdc598-8939-11e3-bea4-8341f6861379",
@@ -1111,7 +1111,7 @@ cat <<EOF
 
   "muppet": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-loadbalancer",
     "image_description": "Manta loadbalancer",
     "image_uuid": "04a48d7d-6bb5-4e83-8c3b-e60a99e0f48f",
@@ -1140,7 +1140,7 @@ cat <<EOF
 
   "muskie": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-webapi",
     "image_description": "Manta webapi",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1168,7 +1168,7 @@ cat <<EOF
 
   "mola": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-ops",
     "image_description": "Manta ops",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1197,7 +1197,7 @@ cat <<EOF
 
   "madtom": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-madtom",
     "image_description": "Manta madtom",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1225,7 +1225,7 @@ cat <<EOF
 
   "marlin-dashboard": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-marlin-dashboard",
     "image_description": "Manta marlin dashboard",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1250,7 +1250,7 @@ cat <<EOF
 
   "mako": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-storage",
     "image_description": "Manta storage",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1279,7 +1279,7 @@ cat <<EOF
 
   "marlin": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-jobsupervisor",
     "image_description": "Manta jobsupervisor",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1305,7 +1305,7 @@ cat <<EOF
 
   "wrasse": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-jobpuller",
     "image_description": "Manta Job Puller",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1331,7 +1331,7 @@ cat <<EOF
 
   "propeller": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-propeller",
     "image_description": "Manta propeller",
     "image_uuid": "fd2cc906-8938-11e3-beab-4359c665ac99",
@@ -1358,7 +1358,7 @@ cat <<EOF
   },
 
   "sdcadm": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdcadm.git"}
     ],
@@ -1368,7 +1368,7 @@ cat <<EOF
 
   "sdcsso": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "sdcsso",
     "image_description": "SDC SSO",
     "image_version": "1.0.0",
@@ -1395,7 +1395,7 @@ cat <<EOF
   },
 
   "agentsshar": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-agents-installer.git"}
     ],
@@ -1417,7 +1417,7 @@ cat <<EOF
   },
 
   "dockerlogger": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {
             "url": "git@github.com:joyent/sdc-dockerlogger.git",
@@ -1431,7 +1431,7 @@ cat <<EOF
 
   "manta-reshard": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-reshard",
     "image_description": "Manta Resharding System",
     "image_version": "1.0.0",
@@ -1458,7 +1458,7 @@ cat <<EOF
 
   "manta-deployment": {
     "appliance": "true",
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "image_name": "manta-deployment",
     "image_description": "Manta deployment tools",
     "image_version": "1.0.0",
@@ -1482,7 +1482,7 @@ cat <<EOF
   },
 
   "sdc-system-tests": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdc-system-tests.git"}
     ],
@@ -1493,7 +1493,7 @@ cat <<EOF
   },
 
   "sdcboot": {
-    "build_platform": "20141030T081701Z",
+    "build_platform": "20151126T062538Z",
     "repos": [
         {"url": "git@github.com:joyent/sdcboot.git"}
     ],


### PR DESCRIPTION
Current distribution of KVM Jenkins build agents that use the new minimum platform that this PR sets:
```
➜  jenkinsadm git:(master) ✗ ./bin/jenkinsadm list | grep 20151126 | while read ID PI KVM PLAT DC IMG_VER ARCH PKGSRC; do if [ $KVM = "Y" ]; then echo $DC $IMG_VER $ARCH; fi; done | sort | uniq -c | sort
   1 staging-1 1.6.3 i386
   1 staging-1 13.3.1 multiarch
   1 staging-1 14.2.0 i386
   2 emy-jenkins 15.4.1 multiarch
   3 staging-3 1.6.3 i386
   3 staging-3 15.4.1 multiarch
➜  jenkinsadm git:(master) ✗ 
```

That should be enough to merge this PR, even if, as mentioned in the associated ticket:

> There will be a window of time between the updates made to MG and the updates made to the Jenkins jobs filters where a build could be triggered with a mismatched min platform, but that's fine.